### PR TITLE
Añadir soporte para MinGW en windows

### DIFF
--- a/builds/cmake/Modules/FindSFML.cmake
+++ b/builds/cmake/Modules/FindSFML.cmake
@@ -77,7 +77,9 @@ set(FIND_SFML_PATHS
 	/sw
 	/opt/local
 	/opt/csw
-	/opt)
+	/opt
+	/MinGW/lib
+	/MinGW)
 
 # find the SFML include directory
 find_path(SFML_INCLUDE_DIR SFML/Config.hpp


### PR DESCRIPTION
He intentado crear un proyecto para Sublimte text editor 2 con MinGW en
windows, y teniendo las librerias de SFML dentro de la carpeta MinGW
(todo en su sitio, laslibrerias en /lib/ y los headers en /include/SFML)
no me las encontraba.

He puesto 2 directorios más a FIND_SFML_PATHS para soportar MinGW.
