### PR TITLE
Agregada regla de instalación para la libreria

### DIFF
--- a/builds/cmake/CMakeLists.txt
+++ b/builds/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Se define la version mínima del CMake
+# Se define la versión mínima del CMake
 cmake_minimum_required(VERSION 2.8)
 
 project(GDE)
@@ -10,14 +10,18 @@ macro(set_option variable default type docstring)
 	set(${variable} ${${variable}} CACHE ${type} ${docstring} FORCE)
 endmacro()
 
-set_option(GDE_BUILD_TYPE Release STRING "Escoje el tipo de build (Debug o Release)") 
+# Establece la versión del proyecto
+set(VERSION_MAJOR 0)
+set(VERSION_MINOR 1)
+set(VERSION_PATCH 0)
+
+set_option(CMAKE_BUILD_TYPE Release STRING "Escoje el tipo de build (Debug o Release)") 
+set_option(BUILD_SHARED_LIBS FALSE BOOL "TRUE para construir GDE como librería compartida, FALSE para construir GDE como librería e" )
 set_option(SFML_STATIC_LIBRARIES FALSE BOOL "TRUE para Linkear SFML estaticamente")
 
-set(CMAKE_BUILD_TYPE ${GDE_BUILD_TYPE})
-
-# Carga el archivo de Configuracion
+# Carga el archivo de Configuración
 include(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake)
-# Le dice a CMake donde van a estar los Modulos
+# Le dice a CMake donde van a estar los Módulos
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Modules)
 
 # Directorio base del proyecto
@@ -29,5 +33,9 @@ set(GDE_INCLUDE_DIR ${GDE_DIR}/include)
 
 # Le dice a CMake donde buscar los Headers
 include_directories(${GDE_INCLUDE_DIR})
+
+# Habilita los directorios en los proyectos
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "CMake")
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/builds/cmake/src/CMakeLists.txt
+++ b/builds/cmake/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Agrega algunos directorios para que CMake busque librerias allí dependiendo del OS
+# Agrega algunos directorios para que CMake busque librerías allí dependiendo del OS
 if (OS_WINDOWS)
 	set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${GDE_DIR}/extlibs/headers")
 	if(COMPILER_GCC)
@@ -33,30 +33,42 @@ file(GLOB_RECURSE GDE_TEST_SOURCE
 	"${GDE_TEST_SOURCE_DIR}/*.cpp"
 )
 
-# Define en que lugar se guardan las librerias y ejecutables
+# Define en que lugar se guardan las librerías y ejecutables
 set(LIBRARY_OUTPUT_PATH ${GDE_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${GDE_DIR}/bin)
 
 # Crea la libreria GDE
-add_library(GDE_LIB STATIC ${GDE_SOURCE} ${GDE_INCLUDES})
+add_library(GDE_LIB ${GDE_SOURCE} ${GDE_INCLUDES})
 # Crea los tests
 add_executable(GDE_TEST ${GDE_TEST_SOURCE})
 
-# Agrega propiedades a cada target
-set_target_properties(GDE_LIB 
-					  PROPERTIES 
-						OUTPUT_NAME_RELEASE "GDE"
-						OUTPUT_NAME_DEBUG "GDE-d"
-						PROJECT_LABEL "GDE"
-)
-set_target_properties(GDE_TEST
-					  PROPERTIES 
-						OUTPUT_NAME_RELEASE "Test"
-						OUTPUT_NAME_DEBUG "Test-d"
-						PROJECT_LABEL "TEST"
-)
 
-# Busca las librerias de SFML
+## Agrega propiedades a cada target
+
+set_target_properties(GDE_LIB PROPERTIES OUTPUT_NAME "GDE")
+# Opciones para la generación de proyectos en algunos IDEs
+set_target_properties(GDE_LIB PROPERTIES PROJECT_LABEL "GDE")
+set_target_properties(GDE_LIB PROPERTIES FOLDER "GDE")
+
+if(BUILD_SHARED_LIBS)
+	set_target_properties(GDE_LIB PROPERTIES DEBUG_POSTFIX -d)
+else()
+	set_target_properties(GDE_LIB PROPERTIES DEBUG_POSTFIX -s-d)	
+	set_target_properties(GDE_LIB PROPERTIES RELEASE_POSTFIX -s)
+	set_target_properties(GDE_LIB PROPERTIES MINSIZEREL_POSTFIX -s)
+endif()
+
+# Establece la version y soversion para algunos OS
+set_target_properties(GDE_LIB PROPERTIES SOVERSION ${VERSION_MAJOR})
+set_target_properties(GDE_LIB PROPERTIES VERSION ${VERSION_MAJOR}.${VERSION_MINOR})
+
+set_target_properties(GDE_TEST PROPERTIES OUTPUT_NAME "Test")
+set_target_properties(GDE_TEST PROPERTIES PROJECT_LABEL "TEST")
+set_target_properties(GDE_TEST PROPERTIES FOLDER "GDE")
+set_target_properties(GDE_TEST PROPERTIES DEBUG_POSTFIX -d)
+
+
+## Busca las librerías de SFML
 find_package(SFML 2.1 COMPONENTS audio network graphics window system REQUIRED)
 if(SFML_FOUND)
 	include_directories(${SFML_INCLUDE_DIR})
@@ -64,3 +76,20 @@ if(SFML_FOUND)
 endif(SFML_FOUND)
 
 target_link_libraries(GDE_TEST GDE_LIB)
+
+
+## Reglas de instalación
+
+# Instala los include de GDE
+install(DIRECTORY ${GDE_INCLUDE_DIR}
+        DESTINATION .
+        COMPONENT development)
+# Instala la librería GDE
+install(TARGETS GDE_LIB
+		RUNTIME DESTINATION bin
+		LIBRARY DESTINATION lib
+		ARCHIVE DESTINATION lib)
+# Instala los tests de GDE
+# install(TARGETS GDE_TEST
+# 		DESTINATION share/GDE/Test
+# 		COMPONENT test)


### PR DESCRIPTION
Se han agregado las reglas de instalación para algunos sistemas y algunas modificaciones a los proyectos generados.
Ahora genera la librería con el prefijo `-s` cuando es estática, `-d` cuando es debug. Justo como lo que hace SFML con las librerías.
