### PR TITLE
Soporte para Xcode 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,18 @@ bin/Test-d
 Makefile
 GDE.txt
 builds/codelite/.*
+
+
+# =======
+# OSX 
+# =======
+
+# Finder's cache files
+.DS_Store
+
+# xcuserdata folders are located inside the xcodeproj and xcworkspace folders
+# contains specific user data for xcode
+xcuserdata
+
+# Xcode Version control metadata
+*.xccheckout

--- a/builds/xcode/GDE.xcodeproj/project.pbxproj
+++ b/builds/xcode/GDE.xcodeproj/project.pbxproj
@@ -1,0 +1,296 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		9C58FF7418300EAF00EA099D /* App.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9C58FF6D18300EAF00EA099D /* App.cpp */; };
+		9C58FF7518300EAF00EA099D /* ConfigCreate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9C58FF6E18300EAF00EA099D /* ConfigCreate.cpp */; };
+		9C58FF7618300EAF00EA099D /* ConfigReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9C58FF6F18300EAF00EA099D /* ConfigReader.cpp */; };
+		9C58FF7718300EAF00EA099D /* Log.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9C58FF7018300EAF00EA099D /* Log.cpp */; };
+		9C58FF7818300EAF00EA099D /* Scene.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9C58FF7118300EAF00EA099D /* Scene.cpp */; };
+		9C58FF7918300EAF00EA099D /* SceneManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9C58FF7218300EAF00EA099D /* SceneManager.cpp */; };
+		9C58FF7A18300EAF00EA099D /* StringUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9C58FF7318300EAF00EA099D /* StringUtil.cpp */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		9C11C132182FF75E00988E31 /* SFML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SFML.framework; path = /Library/Frameworks/SFML.framework; sourceTree = "<absolute>"; };
+		9C13D80518300A6200F67BF4 /* GDE */ = {isa = PBXFileReference; lastKnownFileType = folder; name = GDE; path = ../../include/GDE; sourceTree = "<group>"; };
+		9C58FF6D18300EAF00EA099D /* App.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = App.cpp; path = ../../src/GDE/Core/App.cpp; sourceTree = "<group>"; };
+		9C58FF6E18300EAF00EA099D /* ConfigCreate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ConfigCreate.cpp; path = ../../src/GDE/Core/ConfigCreate.cpp; sourceTree = "<group>"; };
+		9C58FF6F18300EAF00EA099D /* ConfigReader.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ConfigReader.cpp; path = ../../src/GDE/Core/ConfigReader.cpp; sourceTree = "<group>"; };
+		9C58FF7018300EAF00EA099D /* Log.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Log.cpp; path = ../../src/GDE/Core/Log.cpp; sourceTree = "<group>"; };
+		9C58FF7118300EAF00EA099D /* Scene.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Scene.cpp; path = ../../src/GDE/Core/Scene.cpp; sourceTree = "<group>"; };
+		9C58FF7218300EAF00EA099D /* SceneManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SceneManager.cpp; path = ../../src/GDE/Core/SceneManager.cpp; sourceTree = "<group>"; };
+		9C58FF7318300EAF00EA099D /* StringUtil.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = StringUtil.cpp; path = ../../src/GDE/Core/StringUtil.cpp; sourceTree = "<group>"; };
+		9CD50CC2182FEBB500CFCACB /* libGDE.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libGDE.a; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		9CD50CBB182FB85C00CFCACB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		9C11C135182FF77A00988E31 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				9C11C132182FF75E00988E31 /* SFML.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		9C11C136182FF78100988E31 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				9CD50CC2182FEBB500CFCACB /* libGDE.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9C13D80318300A4500F67BF4 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				9C13D80518300A6200F67BF4 /* GDE */,
+			);
+			name = include;
+			sourceTree = "<group>";
+		};
+		9C13D80418300A4B00F67BF4 /* source */ = {
+			isa = PBXGroup;
+			children = (
+				9C58FF7B18300EBC00EA099D /* Core */,
+			);
+			name = source;
+			sourceTree = "<group>";
+		};
+		9C5867C6182F9B95007AC8CC = {
+			isa = PBXGroup;
+			children = (
+				9C13D80418300A4B00F67BF4 /* source */,
+				9C13D80318300A4500F67BF4 /* include */,
+				9C11C135182FF77A00988E31 /* Frameworks */,
+				9C11C136182FF78100988E31 /* Products */,
+			);
+			sourceTree = "<group>";
+			usesTabs = 1;
+		};
+		9C58FF7B18300EBC00EA099D /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				9C58FF6D18300EAF00EA099D /* App.cpp */,
+				9C58FF6E18300EAF00EA099D /* ConfigCreate.cpp */,
+				9C58FF6F18300EAF00EA099D /* ConfigReader.cpp */,
+				9C58FF7018300EAF00EA099D /* Log.cpp */,
+				9C58FF7118300EAF00EA099D /* Scene.cpp */,
+				9C58FF7218300EAF00EA099D /* SceneManager.cpp */,
+				9C58FF7318300EAF00EA099D /* StringUtil.cpp */,
+			);
+			name = Core;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		9CD50CBC182FB85C00CFCACB /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		9CD50CBD182FB85C00CFCACB /* GDE */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9CD50CBF182FB85C00CFCACB /* Build configuration list for PBXNativeTarget "GDE" */;
+			buildPhases = (
+				9CD50CBA182FB85C00CFCACB /* Sources */,
+				9CD50CBB182FB85C00CFCACB /* Frameworks */,
+				9CD50CBC182FB85C00CFCACB /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = GDE;
+			productName = Test;
+			productReference = 9CD50CC2182FEBB500CFCACB /* libGDE.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		9C5867C7182F9B95007AC8CC /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0500;
+			};
+			buildConfigurationList = 9C5867CA182F9B95007AC8CC /* Build configuration list for PBXProject "GDE" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 9C5867C6182F9B95007AC8CC;
+			productRefGroup = 9C5867C6182F9B95007AC8CC;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				9CD50CBD182FB85C00CFCACB /* GDE */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		9CD50CBA182FB85C00CFCACB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9C58FF7418300EAF00EA099D /* App.cpp in Sources */,
+				9C58FF7518300EAF00EA099D /* ConfigCreate.cpp in Sources */,
+				9C58FF7618300EAF00EA099D /* ConfigReader.cpp in Sources */,
+				9C58FF7718300EAF00EA099D /* Log.cpp in Sources */,
+				9C58FF7818300EAF00EA099D /* Scene.cpp in Sources */,
+				9C58FF7918300EAF00EA099D /* SceneManager.cpp in Sources */,
+				9C58FF7A18300EAF00EA099D /* StringUtil.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		9C5867CB182F9B95007AC8CC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ONLY_ACTIVE_ARCH = YES;
+			};
+			name = Debug;
+		};
+		9C5867CC182F9B95007AC8CC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		9CD50CC0182FB85C00CFCACB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				EXECUTABLE_PREFIX = lib;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(LOCAL_LIBRARY_DIR)/Frameworks",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INSTALL_PATH = build/osx;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SYMROOT = ../../bin;
+				USER_HEADER_SEARCH_PATHS = "../../include/**";
+			};
+			name = Debug;
+		};
+		9CD50CC1182FB85C00CFCACB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				EXECUTABLE_PREFIX = lib;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(LOCAL_LIBRARY_DIR)/Frameworks",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INSTALL_PATH = build/osx;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SYMROOT = ../../bin;
+				USER_HEADER_SEARCH_PATHS = "../../include/**";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		9C5867CA182F9B95007AC8CC /* Build configuration list for PBXProject "GDE" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9C5867CB182F9B95007AC8CC /* Debug */,
+				9C5867CC182F9B95007AC8CC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		9CD50CBF182FB85C00CFCACB /* Build configuration list for PBXNativeTarget "GDE" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9CD50CC0182FB85C00CFCACB /* Debug */,
+				9CD50CC1182FB85C00CFCACB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 9C5867C7182F9B95007AC8CC /* Project object */;
+}

--- a/builds/xcode/GDE.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/builds/xcode/GDE.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Genbeta Dev Engine.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/builds/xcode/Genbeta Dev Engine.xcworkspace/contents.xcworkspacedata
+++ b/builds/xcode/Genbeta Dev Engine.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:gde-test.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:GDE.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/builds/xcode/gde-test.xcodeproj/project.pbxproj
+++ b/builds/xcode/gde-test.xcodeproj/project.pbxproj
@@ -1,0 +1,314 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		9C58FF8318300F8900EA099D /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9C58FF7E18300F7D00EA099D /* main.cpp */; };
+		9C58FF8418300F8900EA099D /* SceneGame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9C58FF7F18300F7D00EA099D /* SceneGame.cpp */; };
+		9C58FF8518300F8900EA099D /* SceneGame.hpp in Sources */ = {isa = PBXBuildFile; fileRef = 9C58FF8018300F7D00EA099D /* SceneGame.hpp */; };
+		9C58FF8618300F8900EA099D /* SceneMain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9C58FF8118300F7D00EA099D /* SceneMain.cpp */; };
+		9C58FF8718300F8900EA099D /* SceneMain.hpp in Sources */ = {isa = PBXBuildFile; fileRef = 9C58FF8218300F7D00EA099D /* SceneMain.hpp */; };
+		9CA17E811830110F00F82564 /* SFML.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9CA17E801830110F00F82564 /* SFML.framework */; };
+		9CA17E871830120400F82564 /* libGDE.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9CA17E861830120400F82564 /* libGDE.a */; };
+		9CA17E8D183012CE00F82564 /* sfml-audio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9CA17E88183012CE00F82564 /* sfml-audio.framework */; };
+		9CA17E8E183012CE00F82564 /* sfml-graphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9CA17E89183012CE00F82564 /* sfml-graphics.framework */; };
+		9CA17E8F183012CE00F82564 /* sfml-network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9CA17E8A183012CE00F82564 /* sfml-network.framework */; };
+		9CA17E90183012CE00F82564 /* sfml-system.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9CA17E8B183012CE00F82564 /* sfml-system.framework */; };
+		9CA17E91183012CE00F82564 /* sfml-window.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9CA17E8C183012CE00F82564 /* sfml-window.framework */; };
+		9CA17E9B18301DF500F82564 /* data in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9CA17E9918301DED00F82564 /* data */; };
+		9CA17E9C18301DF500F82564 /* window.cfg in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9CA17E9A18301DED00F82564 /* window.cfg */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		9C11C11B182FEFCA00988E31 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 12;
+			dstPath = "";
+			dstSubfolderSpec = 16;
+			files = (
+				9CA17E9B18301DF500F82564 /* data in CopyFiles */,
+				9CA17E9C18301DF500F82564 /* window.cfg in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		9C11C11D182FEFCA00988E31 /* gde-test */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "gde-test"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9C58FF7E18300F7D00EA099D /* main.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = main.cpp; path = ../../src/Test/main.cpp; sourceTree = "<group>"; };
+		9C58FF7F18300F7D00EA099D /* SceneGame.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SceneGame.cpp; path = ../../src/Test/SceneGame.cpp; sourceTree = "<group>"; };
+		9C58FF8018300F7D00EA099D /* SceneGame.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = SceneGame.hpp; path = ../../src/Test/SceneGame.hpp; sourceTree = "<group>"; };
+		9C58FF8118300F7D00EA099D /* SceneMain.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = SceneMain.cpp; path = ../../src/Test/SceneMain.cpp; sourceTree = "<group>"; };
+		9C58FF8218300F7D00EA099D /* SceneMain.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = SceneMain.hpp; path = ../../src/Test/SceneMain.hpp; sourceTree = "<group>"; };
+		9CA17E801830110F00F82564 /* SFML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SFML.framework; path = /Library/Frameworks/SFML.framework; sourceTree = "<absolute>"; };
+		9CA17E861830120400F82564 /* libGDE.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libGDE.a; path = "../../../../../Library/Developer/Xcode/DerivedData/Genbeta_Dev_Engine-bzvomkrxmzaewbgibtylvredwwjh/Build/Products/Debug/libGDE.a"; sourceTree = "<group>"; };
+		9CA17E88183012CE00F82564 /* sfml-audio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = "sfml-audio.framework"; path = "../../../../../../../Library/Frameworks/sfml-audio.framework"; sourceTree = "<group>"; };
+		9CA17E89183012CE00F82564 /* sfml-graphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = "sfml-graphics.framework"; path = "../../../../../../../Library/Frameworks/sfml-graphics.framework"; sourceTree = "<group>"; };
+		9CA17E8A183012CE00F82564 /* sfml-network.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = "sfml-network.framework"; path = "../../../../../../../Library/Frameworks/sfml-network.framework"; sourceTree = "<group>"; };
+		9CA17E8B183012CE00F82564 /* sfml-system.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = "sfml-system.framework"; path = "../../../../../../../Library/Frameworks/sfml-system.framework"; sourceTree = "<group>"; };
+		9CA17E8C183012CE00F82564 /* sfml-window.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = "sfml-window.framework"; path = "../../../../../../../Library/Frameworks/sfml-window.framework"; sourceTree = "<group>"; };
+		9CA17E9918301DED00F82564 /* data */ = {isa = PBXFileReference; lastKnownFileType = folder; name = data; path = ../../bin/data; sourceTree = "<group>"; };
+		9CA17E9A18301DED00F82564 /* window.cfg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = window.cfg; path = ../../bin/window.cfg; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		9C11C11A182FEFCA00988E31 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9CA17E8D183012CE00F82564 /* sfml-audio.framework in Frameworks */,
+				9CA17E8E183012CE00F82564 /* sfml-graphics.framework in Frameworks */,
+				9CA17E8F183012CE00F82564 /* sfml-network.framework in Frameworks */,
+				9CA17E90183012CE00F82564 /* sfml-system.framework in Frameworks */,
+				9CA17E91183012CE00F82564 /* sfml-window.framework in Frameworks */,
+				9CA17E871830120400F82564 /* libGDE.a in Frameworks */,
+				9CA17E811830110F00F82564 /* SFML.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		9C11C114182FEFCA00988E31 = {
+			isa = PBXGroup;
+			children = (
+				9CA17E9918301DED00F82564 /* data */,
+				9CA17E9A18301DED00F82564 /* window.cfg */,
+				9CA17E82183011E100F82564 /* Frameworks */,
+				9C58FF7D18300F7500EA099D /* Test */,
+				9C11C11E182FEFCA00988E31 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		9C11C11E182FEFCA00988E31 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				9C11C11D182FEFCA00988E31 /* gde-test */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9C58FF7D18300F7500EA099D /* Test */ = {
+			isa = PBXGroup;
+			children = (
+				9C58FF7E18300F7D00EA099D /* main.cpp */,
+				9C58FF7F18300F7D00EA099D /* SceneGame.cpp */,
+				9C58FF8018300F7D00EA099D /* SceneGame.hpp */,
+				9C58FF8118300F7D00EA099D /* SceneMain.cpp */,
+				9C58FF8218300F7D00EA099D /* SceneMain.hpp */,
+			);
+			name = Test;
+			sourceTree = "<group>";
+		};
+		9CA17E82183011E100F82564 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				9CA17E88183012CE00F82564 /* sfml-audio.framework */,
+				9CA17E89183012CE00F82564 /* sfml-graphics.framework */,
+				9CA17E8A183012CE00F82564 /* sfml-network.framework */,
+				9CA17E8B183012CE00F82564 /* sfml-system.framework */,
+				9CA17E8C183012CE00F82564 /* sfml-window.framework */,
+				9CA17E861830120400F82564 /* libGDE.a */,
+				9CA17E801830110F00F82564 /* SFML.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		9C11C11C182FEFCA00988E31 /* gde-test */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9C11C126182FEFCA00988E31 /* Build configuration list for PBXNativeTarget "gde-test" */;
+			buildPhases = (
+				9C11C119182FEFCA00988E31 /* Sources */,
+				9C11C11A182FEFCA00988E31 /* Frameworks */,
+				9C11C11B182FEFCA00988E31 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "gde-test";
+			productName = "gde-test";
+			productReference = 9C11C11D182FEFCA00988E31 /* gde-test */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		9C11C115182FEFCA00988E31 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0500;
+			};
+			buildConfigurationList = 9C11C118182FEFCA00988E31 /* Build configuration list for PBXProject "gde-test" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 9C11C114182FEFCA00988E31;
+			productRefGroup = 9C11C11E182FEFCA00988E31 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				9C11C11C182FEFCA00988E31 /* gde-test */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		9C11C119182FEFCA00988E31 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9C58FF8318300F8900EA099D /* main.cpp in Sources */,
+				9C58FF8418300F8900EA099D /* SceneGame.cpp in Sources */,
+				9C58FF8518300F8900EA099D /* SceneGame.hpp in Sources */,
+				9C58FF8618300F8900EA099D /* SceneMain.cpp in Sources */,
+				9C58FF8718300F8900EA099D /* SceneMain.hpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		9C11C124182FEFCA00988E31 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CONFIGURATION_TEMP_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				OBJROOT = /build/tmp;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SYMROOT = ../../bin;
+				USER_HEADER_SEARCH_PATHS = "../../include/**";
+			};
+			name = Debug;
+		};
+		9C11C125182FEFCA00988E31 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CONFIGURATION_TEMP_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				OBJROOT = /build/tmp;
+				SDKROOT = macosx;
+				SYMROOT = ../../bin;
+				USER_HEADER_SEARCH_PATHS = "../../include/**";
+			};
+			name = Release;
+		};
+		9C11C127182FEFCA00988E31 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(LOCAL_LIBRARY_DIR)/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/Genbeta_Dev_Engine-bzvomkrxmzaewbgibtylvredwwjh/Build/Products/Debug",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYMROOT = ../../bin;
+			};
+			name = Debug;
+		};
+		9C11C128182FEFCA00988E31 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(LOCAL_LIBRARY_DIR)/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/Genbeta_Dev_Engine-bzvomkrxmzaewbgibtylvredwwjh/Build/Products/Debug",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYMROOT = ../../bin;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		9C11C118182FEFCA00988E31 /* Build configuration list for PBXProject "gde-test" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9C11C124182FEFCA00988E31 /* Debug */,
+				9C11C125182FEFCA00988E31 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9C11C126182FEFCA00988E31 /* Build configuration list for PBXNativeTarget "gde-test" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9C11C127182FEFCA00988E31 /* Debug */,
+				9C11C128182FEFCA00988E31 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 9C11C115182FEFCA00988E31 /* Project object */;
+}

--- a/builds/xcode/gde-test.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/builds/xcode/gde-test.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:gde-test.xcodeproj">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
El proyecto está en builds/xcode

Tiene definido un workspace con dos proyectos:
- GDE: target para generar una librería estática **libGDE.a**. (más adelante habrá que generar otro target que construya la versión dinámica)
  - gde-test: target para generar una app de consola, con dependencia en libGDE.a

Ahora mismo el ejecutable finale se genera en un directorio temporal ~/Library/Developer/Xcode/???? que no se cómo cambiar, por que Xcode es un poco especialito. Cuando sepa cambiarlo actualizaré esto.
