### PR TITLE
Fixes/string concatenation

### DIFF
--- a/include/GDE/Core/StringsUtil.hpp
+++ b/include/GDE/Core/StringsUtil.hpp
@@ -317,6 +317,16 @@ std::string GDE_API StringToLowercase(std::string theString);
  **/
 std::string GDE_API StringToUppercase(std::string theString);
 
+/**
+ * Permite formatear una std::string como en una llamada a printf, usando una
+ * lista de argumentos variable.
+ *
+ * @param[in] stringToFormat: String con el formato.
+ * @param[in] args: Lista variable de argumentos con los elementos a sustituir
+ * @return std::string: Nueva string formateada con los argumentos pasados
+ **/
+std::string GDE_API StringFormat(const std::string stringToFormat, ...);
+
 } // namespace GDE
 
 #endif // GDE_CORE_STRING_UTIL_HPP

--- a/src/GDE/Core/ConfigReader.cpp
+++ b/src/GDE/Core/ConfigReader.cpp
@@ -181,7 +181,7 @@ bool ConfigReader::loadFromFile(const std::string& theFilename)
                 // Si ocurre un error lo metemos en el log
                 if (!feof(anFile))
                 {
-                    GDE::Log::error("ConfigReader::Read", "Error leyendo la línea " + anCount);
+                    GDE::Log::error("ConfigReader::Read", StringFormat("Error leyendo la línea %d", anCount));
                 }
                 // Salimos del bucle
                 break;
@@ -204,7 +204,7 @@ bool ConfigReader::loadFromFile(const std::string& theFilename)
     }
     else
     {
-        GDE::Log::error("ConfigReader::loadFromFile","Error al leer fichero " + theFilename+".");
+        GDE::Log::error("ConfigReader::loadFromFile", StringFormat("Error al leer fichero %s .", theFilename.c_str()));
     }
 
     // Devuelve true en caso de éxito, false en caso contrario
@@ -281,7 +281,8 @@ std::string ConfigReader::parseLine(const char* theLine,
                 }
                 else
                 {
-                    GDE::Log::error("ConfigReader::parseLine", "No se encontró el delimitador de sección ']' en la línea " + theCount);
+                    GDE::Log::error("ConfigReader::parseLine",
+									StringFormat("No se encontró el delimitador de sección ']' en la línea %d", theCount));
                 }
             }
             // Leemos el par <clave,valor> de la sección actual.
@@ -353,7 +354,8 @@ std::string ConfigReader::parseLine(const char* theLine,
                 }
                 else
                 {
-                    GDE::Log::error("ConfigReader::parseLine","No se encontró el delimitador de nombre o valor '=' o ':' en la línea " + theCount);
+                    GDE::Log::error("ConfigReader::parseLine",
+									StringFormat("No se encontró el delimitador de nombre o valor '=' o ':' en la línea %d", theCount));
                 }
             }
         } // if(theLine[anOffset] != '#' && theLine[anOffset] != ';')

--- a/src/GDE/Core/StringUtil.cpp
+++ b/src/GDE/Core/StringUtil.cpp
@@ -587,4 +587,43 @@ std::string StringToUppercase(std::string theString)
 	return anLowerString;
 }
 
+std::string GDE_API StringFormat(const std::string stringToFormat, ...) {
+	int streamBufferSize = 100;
+	std::string formattedString;
+
+	va_list argumentParameters;
+
+	formattedString.resize(streamBufferSize);
+
+	va_start(argumentParameters, stringToFormat);
+	// Compute the number of characters the final formatted string will have
+	int numChars = vsnprintf((char *)formattedString.c_str(),
+							 streamBufferSize,
+							 stringToFormat.c_str(),
+							 argumentParameters);
+
+
+	// The formatted string could be stored in the initial buffer size
+	if (numChars > -1 && numChars < streamBufferSize) {
+		formattedString.resize(numChars);
+
+		return formattedString;
+	// The formatted string does not fit in the initial buffer size
+	} else {
+		// Resize the buffer and add space for the null-terminating char
+		streamBufferSize = numChars + 1;
+		formattedString.resize(streamBufferSize);
+
+		// This second call will create the complete formatted string
+		va_start(argumentParameters, stringToFormat);
+		vsnprintf((char *)formattedString.c_str(),
+				  streamBufferSize,
+				  stringToFormat.c_str(),
+				  argumentParameters);
+	}
+
+	va_end(argumentParameters);
+	return formattedString;
+}
+
 } // namespace GDE


### PR DESCRIPTION
Corrige errores al concatenar cadenas con enteros usando el operador +.

Se ha añadido la función StringFormat que permite formatear std::string al estilo de printf().
