### PR TITLE
Ahora busca las dependencias de SFML en la carpeta extlibs en caso que se linkee SFML estáticamente

### DIFF
--- a/builds/cmake/CMakeLists.txt
+++ b/builds/cmake/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Se define la versión mínima del CMake
 cmake_minimum_required(VERSION 2.8)
 
-project(GDE)
-
 macro(set_option variable default type docstring)
 	if(NOT DEFINED ${variable})
 		set(${variable} ${default})
@@ -10,17 +8,26 @@ macro(set_option variable default type docstring)
 	set(${variable} ${${variable}} CACHE ${type} ${docstring} FORCE)
 endmacro()
 
+# Tiene que definirse el tipo de build antes del nombre del proyecto
+set_option(CMAKE_BUILD_TYPE Release STRING "Escoje el tipo de build (Debug o Release)")
+
+project(GDE)
+
+# Carga el archivo de Configuración
+include(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake)
+
 # Establece la versión del proyecto
 set(VERSION_MAJOR 0)
 set(VERSION_MINOR 1)
 set(VERSION_PATCH 0)
 
-set_option(CMAKE_BUILD_TYPE Release STRING "Escoje el tipo de build (Debug o Release)") 
 set_option(BUILD_SHARED_LIBS FALSE BOOL "TRUE para construir GDE como librería compartida, FALSE para construir GDE como librería estática" )
 set_option(SFML_STATIC_LIBRARIES FALSE BOOL "TRUE para Linkear SFML estaticamente")
 
-# Carga el archivo de Configuración
-include(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake)
+if(OS_WINDOWS)
+	set_option(BUILD_GUI_TESTS FALSE BOOL "TRUE para construir los TESTS sin símbolo del sistema (CMD)")
+endif()
+
 # Le dice a CMake donde van a estar los Módulos
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Modules)
 

--- a/builds/cmake/src/CMakeLists.txt
+++ b/builds/cmake/src/CMakeLists.txt
@@ -48,8 +48,11 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${GDE_DIR}/bin)
 # Crea la librería GDE
 add_library(GDE_LIB ${GDE_SOURCE} ${GDE_INCLUDES})
 # Crea los tests
-add_executable(GDE_TEST ${GDE_TEST_SOURCE})
-
+if(OS_WINDOWS AND BUILD_GUI_TESTS)
+	add_executable(GDE_TEST WIN32 ${GDE_TEST_SOURCE})
+else()
+	add_executable(GDE_TEST ${GDE_TEST_SOURCE})
+endif()
 
 ## Agrega propiedades a cada target
 
@@ -77,9 +80,16 @@ set_target_properties(GDE_TEST PROPERTIES DEBUG_POSTFIX -d)
 
 
 ## Busca las librerías de SFML
-find_package(SFML 2.1 COMPONENTS audio network graphics window system REQUIRED)
+if(OS_WINDOWS)
+	find_package(SFML 2.1 COMPONENTS main audio graphics window system REQUIRED)
+else()
+	find_package(SFML 2.1 COMPONENTS audio graphics window system REQUIRED)
+endif()
 if(SFML_FOUND)
 	include_directories(${SFML_INCLUDE_DIR})
+	if(SFML_STATIC_LIBRARIES)
+		target_link_libraries(GDE_LIB ${SFML_DEPENDENCIES})
+	endif()
 	target_link_libraries(GDE_LIB ${SFML_LIBRARIES})
 endif(SFML_FOUND)
 


### PR DESCRIPTION
Pull request con respecto al issue #65
