### PR TITLE
Log con streams y operador <<

### DIFF
--- a/include/GDE/Core/CoreTypes.hpp
+++ b/include/GDE/Core/CoreTypes.hpp
@@ -14,13 +14,13 @@ class SceneManager;
 class ConfigReader;
 class ConfigCreate;
 	
-// Tipos de Log
-enum LogType
+/// Nivel o tipo de Log
+enum LogLevel
 {
-	infoLevel = 0,
-	debugLevel = 1,
-	errorLevel = 2,
-	warningLevel = 3
+	Debug = 0,
+	Info = 1,
+	Warning = 2,
+	Error = 3
 };
 
 /// Enumaración con los posibles valores de retorno de la Aplicación
@@ -49,6 +49,30 @@ typedef std::map<const std::string, const std::string> typeNameValue;
 
 /// Declare NameValueIter typedef which is used for name,value pair maps
 typedef std::map<const std::string, const std::string>::iterator typeNameValueIter;
+
+
+/// Almacena el número de línea, nombre de archivo y nombre de función.
+struct SourceContext
+{
+	SourceContext (const char *file, unsigned int line, const char *function)
+	: file(file)
+	, line(line)
+	, function(function)
+	{ }
+
+	const char *file;
+	const int line;
+	const char *function;
+};
+
+
+typedef void (*LogHandler) (std::ostream &os,
+									 GDE::LogLevel level,
+									 const std::string &message,
+									 const std::string &date,
+									 const std::string &time,
+									 const GDE::SourceContext &context
+									);
 
 } // namespace GDE
 

--- a/include/GDE/Core/Log.hpp
+++ b/include/GDE/Core/Log.hpp
@@ -1,103 +1,453 @@
 #ifndef GDE_CORE_LOG_HPP
 #define GDE_CORE_LOG_HPP
 
-#include <string>
-#include <ctime>
-#include <fstream>
-#include <iostream>
+#include <GDE/Config.hpp>
 #include <GDE/Core/CoreTypes.hpp>
+#include <sstream>
+#include <ctime>
 
 namespace GDE
 {
-
 	/**
-	 * Clase que ofrece funcionalidad para almacenar información en un log.
-	 * 
-	 * Es una clase con miembros estáticos por tanto no es necesario crear instancias
-	 * de la clase.
-	 * 
-	 * La forma correcta de usar la clase es inicializando el módulo de la siguiente manera:
-	 * 
-	 * GDE::Log::init("/home/usuario/log.txt");
-	 * 
-	 * Una vez inicializado el módulo ya se puede escribir en el log mediante:
-	 * 
-	 * GDE::Log::info("AssetManager","Cargando texturas");
-	 * GDE::Log::debug("AssetManager","Cargando texturas");
-	 * GDE::Log::error("AssetManager","No se pudieron cargar las texturas");
-	 * 
+	 * @brief Clase que permite almacenar información en un log usando streams.
+	 *
+	 * @section init Inicializando los registros
+	 *
+	 * Antes de poder usar el sistema de registro, debe llamar al método estático GDE::Log::init()
+	 * el cual pide como argumento una referencia a un objeto de tipo @c std::ostream en donde
+	 * se imprimirá el registro. Todo objeto de tipo @c std::ostream o uno de sus derivados
+	 * son válidos, pero las opciones más normales son:
+	 * @li @c std::fstream para escribir en un archivo
+	 * @li @c std::stringstream para escribir en una cadena de texto
+	 * @li @c std::cout o @c std::cerr para escribir directamente en la salida estándar
+	 *
+	 * Si decide usar un archivo, debe crear una instancia de un objeto @c std::fstream y abrir
+	 * el archivo para escritura en modo texto (normalmente usando el modo @c std::ios::app).
+	 * <b>ES MUY IMPORTANTE QUE EL OBJETO PERMANEZCA VÁLIDO Y EL ARCHIVO NO SEA CERRADO.</b>
+	 * Por ejemplo, para usar un archivo llamado "logs.txt":
+	 *
+	 * @code
+	 * int main ()
+	 * {
+	 *     std::ofstream file ("logs.txt", std::ios::app);
+	 *     GDE::Log::init (file);
+	 *
+	 *     // ...
+	 *     // file debe permanecer abierto mientras se use Log
+	 *
+	 *     GDE::Log::close();
+	 *     file.close();
+	 *     return 0;
+	 * }
+	 * @endcode
+	 *
+	 * Nunca haga algo como esto:
+	 *
+	 * @code
+	 * SuperClass::SuperClass()  // constructor de la clase SuperClass
+	 * {
+	 *     std::ofstream file ("logs.txt", std::ios::app);
+	 *     GDE::Log::init (file);
+	 * }
+	 * @endcode
+	 *
+	 * En el código anterior el objeto @e file solo existe dentro del constructor y será
+	 * destruido automáticamente cuando el constructor termine, dejando la clase GDE::Log en un
+	 * estado indeterminado. Si realmente desea inicializar los registros dentro de una clase,
+	 * debe hacer algo similar a:
+	 *
+	 * @code
+	 * class SuperClass
+	 * {
+	 * public:
+	 *     SuperClass();
+	 *     ~SuperClass();
+	 *
+	 * private:
+	 *     std::ofstream file;
+	 * }
+	 *
+	 * SuperClass::SuperClass()
+	 * {
+	 *     file.open ("logs.txt", std::ios:app);
+	 *     GDE::Log::init (file);
+	 * }
+	 *
+	 * SuperClass::~SuperClass()
+	 * {
+	 *     file.close();
+	 *     GDE::Log::close();
+	 * }
+	 * @endcode
+	 *
+	 * La diferencia radica en que ahora @e file es un miembro de la clase, y como tal, su vida
+	 * se prolonga hasta que el objeto de tipo @e SuperClass sea destruido. Este es un buen momento
+	 * para llamar al método GDE::Log::close().
+	 *
+	 * Tenga en cuenta que la responsabilidad de la correcta apertura del archivo recae en usted.
+	 * Debe comprobar que el archivo se haya abierto correctamente antes de entregar el parámetro al
+	 * método GDE::Log::init().
+	 *
+	 * Si desea utilizar @c std::cerr como objeto de salida, simplemente llame al método GDE::Log::init()
+	 * del siguiente modo:
+	 *
+	 * @code
+	 * GDE::Log::init(std::cerr);
+	 * @endcode
+	 *
+	 * De este modo, todos los mensajes irán a parar a la salida estándar de errores.
+	 *
+	 *
+	 * @section using Escribiendo registros
+	 *
+	 * No intente crear un objeto de tipo GDE::Log manualmente, en cambio, haga uso de las macros
+	 * GDE_LOG_INFO, GDE_LOG_DEBUG, GDE_LOG_WARNING y GDE_LOG_ERROR.
+	 *
+	 * Ejemplos:
+	 * @code
+	 * GDE_LOG_DEBUG("SceneManager: Constructor llamado";
+	 * GDE_LOG_INFO("VSync:" << this->vsync);
+	 * GDE_LOG_WARNING("El valor de a =" << a << "es mayor que b =" << b);
+	 * GDE_LOG_INFO("Resolución:" << GDE::Log::nospace << videoMode.width << "x" << videoMode.height);
+	 * @endcode
+	 *
+	 * Escribiría algo similar a:
+	 * @code
+	 * 21:20:34 DEBUG: SceneManager: Constructor llamado
+	 * 21:20:34 INFO: VSync: true
+	 * 21:20:34 WARNING: El valor de a = 7 es mayor que b = 3
+	 * 21:20:34 INFO: Resolución: 800x600
+	 * @endcode
+	 *
+	 * Note que no es necesario colocar explícitamente una nueva línea en el flujo. El caracter @e \\n
+	 * será colocado automáticamente. También debe notar que no es necesario dejar un espacio en blanco
+	 * entre los valores, esto se hace automáticamente por defecto. Este comportamiento puede ser
+	 * cambiado usando los manipuladores space y nospace.
+	 *
+	 * La macro GDE_LOG_ERROR imprime además el nombre de archivo, número de línea y nombre de función
+	 * donde ocurrió el error.
+	 *
+	 *
+	 * @section custom_debug Información de depuración para tipos de datos personalizados
+	 *
+	 * La clase GDE::Log hace un uso extensivo de @c std::stringstream, por tanto todos los tipos de
+	 * datos aceptados por este pueden usarse en GDE::Log. Sin embargo, muchas veces resulta útil
+	 * sobrecargar @c operator<< para usar los streams sobre clases nuevas.
+	 *
+	 * En el siguiente ejemplo asumimos que usted tiene una clase llamada @e MyPoint la cual representa
+	 * un punto a través de sus coordenadas x e y. La implementación para el operador será similar a la
+	 * siguiente:
+	 *
+	 * @code
+	 * GDE::Log& operator<< (GDE::Log& stream, const MyPoint &p)
+	 * {
+	 *     using namespace GDE;
+	 *
+	 *     stream << Log::nospace << "(" << p.x() << ", " << p.y() << ")";
+	 *     stream << Log::space;
+	 *     return stream;
+	 * }
+	 *
+	 * // ...
+	 *
+	 * MyPoint pos(10, 34);
+	 * GDE_LOG_INFO("Posición del personaje:" << pos);
+	 * @endcode
+	 *
+	 *
+	 * @section custom_handler Personalizando la forma en que se imprimen los mensajes
+	 *
+	 * LA FUNCIONALIDAD DESCRITA EN ESTA SECCIÓN AUN NO ESTÁ COMPLETAMENTE IMPLEMENTADA.
+	 *
+	 * La clase GDE::Log le permite modificar la forma en que se escriben los mensajes instalando
+	 * un controlador (handler) personalizado. Para crear su propio controlador debe crear una función
+	 * con exactamente estos argumentos:
+	 *
+	 * @code
+	 * void myLogHandler (std::ostream &os,
+	 *                    GDE::LogLevel level,
+	 *                    const std::string &message,
+	 *                    const std::string &date,
+	 *                    const std::string &time,
+	 *                    const GDE::SourceContext &context
+	 *                   )
+	 * {
+	 *
+     * }
+	 * @endcode
+	 *
+	 * El objeto de tipo @c std::ostream es el lugar donde debe escribir todos los mensajes. El parámetro
+	 * @e level es uno de los valores: GDE::Debug, GDE::Info, GDE::Warning o GDE::Error. @e message es el
+	 * mensaje que la clase GDE::Log ha formateado. @e date es un texto que almacena la fecha actual y
+	 * @e time es un texto que almacena la hora actual. El parámetro @e context es una estructura que
+	 * contiene los miembros: @e file, @e line, @e function, que representan el nombre de archivo, número
+	 * de línea y nombre de función donde ocurrió la llamada.
+	 *
+	 * Un ejemplo de un controlador de mensajes personalizado podría ser como el siguiente:
+	 *
+	 * @code
+	 * void myLogHandler (std::ostream &os,
+	 *                    GDE::LogLevel level,
+	 *                    const std::string &message,
+	 *                    const std::string &date,
+	 *                    const std::string &time,
+	 *                    const GDE::SourceContext &context
+	 *                   )
+	 * {
+	 *     switch (level)
+	 *     {
+	 *     case GDE::Debug:
+	 *         os << time << ": " << "DEBUG: " << message;
+	 *         break;
+	 *
+	 *     case GDE::Info:
+	 *         os << time << ": " << "INFO: " << message;
+	 *         break;
+	 *
+	 *     case GDE::Warning:
+	 *         os << time << ": " << context.file << ":" << context.line << ":" << context.function;
+	 *         os << "WARNING: " << message;
+	 *         break;
+	 *
+	 *     case GDE::Error:
+	 *         os << time << ": " << context.file << ":" << context.line << ":" << context.function;
+	 *         os << "ERROR: " << message;
+	 *         break;
+     *     }
+	 * }
+	 * @endcode
+	 *
+	 * No debe colocar el salto de línea final, esto lo hará la clase GDE::Log.
+	 *
+	 * Para instalar ahora el controlador que acaba de crear, debe usar el método GDE::Log::installHandler()
+	 * pasando como parámetro el puntero a la función que acaba de crear:
+	 *
+	 * @code
+	 * GDE::Log::installHandler(myLogHandler);
+	 * @endcode
+	 *
+	 * Si bien, esto puede hacerse en cualquier punto, es más recomendable hacerlo solo una vez al comienzo,
+	 * antes de usar la clase GDE::Log para escribir.
 	 */
-	
-class GDE_API Log {
+class GDE_API Log
+{
+	Log (const Log &);
+	Log& operator= (const Log &);
+
 public:
+	//=======================================================================================
+	//                                    Clase Manipulator
+	//=======================================================================================
+	template <typename ArgType>
+	class Manipulator
+	{
+	public:
+		typedef Log& (*FunctionPointer) (Log&, ArgType);
 
-    /**
-     * Función para inicializar el sistema de logs. 
-	 * 
-	 * @param logFileName ruta del log a escribir
-     */
+		Manipulator (FunctionPointer fp, const ArgType &arg) : function(fp), arg(arg)  { }
+		Log& operator() (Log& a) const { return (*function)(a, arg); }
 
-    static void init(std::string logFileName);
-    
-    /**
-     * Función para escribir en el log información. Para hacer uso
-     * de dicha función hay que inicializar previamente el sistema.
-     * 
-     * @param tag Etiqueta de la línea a escribir.
-     * @param text texto a escribir.
-     */
-     
-    static void info(std::string tag, std::string text);
-    
-    /**
-     * Función para escribir en el log información de depuración. Para hacer uso
-     * de dicha función hay que inicializar previamente el sistema.
-     * 
-     * @param tag Etiqueta de la línea a escribir.
-     * @param text texto a escribir.
-     */
-     
-    static void debug(std::string tag, std::string text);
-    
-    /**
-     * Función para escribir en el log errores. Para hacer uso
-     * de dicha función hay que inicializar previamente el sistema.
-     * 
-     * @param tag Etiqueta de la línea a escribir.
-     * @param text texto a escribir.
-     */
-     
-    static void error(std::string tag, std::string text);
-	
+	private:
+		FunctionPointer function;
+		ArgType arg;
+	};
+
+
+
+	//=======================================================================================
+	//                                       Clase Log
+	//=======================================================================================
+
+	Log (LogLevel level, const char *file, int line, const char *function);
+	~Log ();
+
 	/**
-     * Función para escribir en el log advertencias. Para hacer uso
-     * de dicha función hay que inicializar previamente el sistema.
-     * 
-     * @param tag Etiqueta de la línea a escribir.
-     * @param text texto a escribir.
-     */
-     
-    static void warning(std::string tag, std::string text);
-     
-    
+	 * Retorna una referencia a @c *this.
+	 *
+	 * No debería llamar a esta función manualmente. Tomar una referencia de un objeto
+	 * temporal puede ser peligroso.
+	 */
+	Log& reference () { return *this; }
+
+	/**
+	 * Inicializa el sistema de logs indicando el flujo donde se imprimirá el mensaje generado.
+	 * @e outputStream debe referenciar a un objeto válido y preparado para recibir información.
+	 * Además, la referencia debe mantenerse válida hasta que el último mensaje sea escrito.
+	 *
+	 * Si el parámetro @e outputStream representa un archivo de tipo @e std::fstream o derivados,
+	 * debe abrir previamente el archivo para escritura y asegurarse que el archivo se haya abierto
+	 * correctamente.
+	 *
+	 * @param outputStream Referencia al flujo donde se imprimirán los mensajes.
+	 */
+	static void init (std::ostream& outputStream);
+
+	/**
+	 * Finaliza el sistema de logs olvidando la referencia al flujo entregado por GDE::Log::init().
+	 *
+	 * Use este método cuando, por ejemplo, desee cerrar el archivo que está usando GDE::Log y
+	 * no desea que GDE::Log lo siga utilizando.
+	 *
+	 * Si el parámetro @e outputStream representa un archivo de tipo @e std::fstream o derivados,
+	 * debe abrir previamente el archivo para escritura y asegurarse que el archivo se haya abierto
+	 * correctamente.
+	 *
+	 * @param outputStream Referencia al flujo donde se imprimirán los mensajes.
+	 */
+	static void close ();
+
+	/**
+	 * Sobrecarga @c operator<< para el tipo @c bool, escribiendo @c true o @c false según
+	 * corresponda.
+	 *
+	 * @param b Valor o variable de tipo @c bool.
+	 */
+	Log& operator<< (bool b);
+
+	/**
+	 * Sobrecarga @c operator<< para el tipo @c std::string. El texto se escribe entre comillas.
+	 *
+	 * @param str Valor o variable de tipo @c std::string.
+	 */
+	Log& operator<< (const std::string &str);
+
+	/**
+	 * Sobrecarga @c operator<< para aceptar manipuladores sin argumentos.
+	 *
+	 * Los manipuladores no son más que un puntero a función que toman una referencia a GDE::Log,
+	 * la modifican adecuadamente y la retornan nuevamente. Este método toma el puntero a función
+	 * y la ejecuta, pasando @c *this como parámetro.
+	 *
+	 * @param manipulator Puntero a función de tipo Log& (Log&) que sirve como manipulador.
+	 */
+	Log& operator<< (Log& (*manipulator)(GDE::Log&)) { return (*manipulator)(*this); }
+
+
+	/**
+	 * Sobrecarga @c operator<< para aceptar manipuladores con un argumento.
+	 *
+	 * Los manipuladores con un argumento se implementan utilizando un objeto función (functor) que
+	 * almacena internamente la dirección de una función y el argumento a utilizar. GDE::Log hace
+	 * uso de la clase plantilla GDE::Log::Manipulator<T> para implementar el objeto función con el
+	 * parámetro indicado. Este operador sobrecargado toma un objeto de tipo GDE::Log::Manipulator<T>
+	 * y lo invoca, pasando @c *this como argumento.
+	 *
+	 * @tparam ArgType Tipo de argumento que usará el manipulador. Este parámetro es deducido
+	 *                 automáticamente por el compilador.
+	 * @param manipulator Objeto función que sirve como manipulador con un argumento.
+	 */
+	template <typename ArgType>
+	Log& operator<< (const Manipulator<ArgType> &manipulator) { return manipulator(*this); }
+
+
+	/**
+	 * Sobrecarga @c operator<< para cualquier tipo de dato aceptado por @c std::stringstream.
+	 *
+	 * @tparam T Un tipo de dato aceptado por \c std::stringstream. Es deducido automáticamente por
+	 *           el compilador.
+	 * @param t Valor o variable de tipo @c T.
+	 */
+	template <typename T> Log& operator<< (T t);
+
+
+	// Manipuladores básicos
+
+	/**
+	 * Manipulador que indica al stream que use un espacio entre cada parámetro pasado.
+	 * Este es el comportamiento por defecto.
+	 *
+	 * @code
+	 * GDE_LOG_INFO(GDE::Log::space << "hola" << "mundo")
+	 * @endcode
+	 *
+	 * Imprime:
+	 *
+	 * @code
+	 * hola mundo
+	 * @endcode
+	 *
+	 *
+	 */
+	static Log& space (Log &o);
+
+	/**
+	 * Manipulador que indica al stream que no coloque un espacio entre cada parámetro pasado.
+	 * Este comportamiento se mantendrá en el stream actual hasta que aparezca el manipulador
+	 * space;
+	 *
+	 * @code
+	 * GDE_LOG_INFO(GDE::Log::nospace << "hola" << "mundo")
+	 * @endcode
+	 *
+	 * Imprime:
+	 *
+	 * @code
+	 * holamundo
+	 * @endcode
+	 */
+	static Log& nospace (Log &o);
+
+
 private:
-  
-    /**
-     * Función base para escribir en el log
-     * 
-     * @param tag Etiqueta de la línea a escribir.
-     * @param text texto a escribir.
-     * @param logType encabezado del log
-     */
-    static void log(std::string tag, std::string text, int logType);
-  
-    static time_t rawtime;
-    static bool initialized;
-    static std::string logFileName;
-    static std::string header[];
-}; // class Log
+	Log& maybeSpace ();
+	static std::string actualTimeToText ();
+
+private:
+	SourceContext context;
+	std::stringstream textStream;
+	bool autoSpacing;
+	LogLevel level;
+	std::string tag;
+
+	static std::ostream *outputStream;
+	static bool initialized;
+	static time_t rawtime;
+	static LogHandler handler;
+};
 
 
-} // namespace GDE
+
+//=======================================================================================
+//                   Definiciones de funciones inline y templates
+//=======================================================================================
+
+template <typename T>
+Log& Log::operator<< (T t)
+{
+	this->textStream << t;
+	return maybeSpace();
+}
+
+
+} // namespace
+
+
+
+//=======================================================================================
+//                                      Macros
+//=======================================================================================
+#   define CRAB_ASSERT(test) \
+    do \
+    { \
+        if (!(test) && Crab::Core::Private::failAssert(#test, \
+                Crab::Core::Context(__FILE__, __LINE__, __PRETTY_FUNCTION__))) \
+        { \
+            CRAB_HALT(); \
+        } \
+    } while(0)
+
+#define GDE_LOG_INFO(MSG) \
+	do { GDE::Log(GDE::Info, __FILE__, __LINE__, __PRETTY_FUNCTION__).reference() << MSG; } while(0)
+
+#define GDE_LOG_DEBUG(MSG) \
+	do { GDE::Log(GDE::Debug, __FILE__, __LINE__, __PRETTY_FUNCTION__).reference() << MSG; } while(0)
+
+#define GDE_LOG_WARNING(MSG) \
+	do { GDE::Log(GDE::Warning, __FILE__, __LINE__, __PRETTY_FUNCTION__).reference() << MSG; } while(0)
+
+#define GDE_LOG_ERROR(MSG) \
+	do { GDE::Log(GDE::Error, __FILE__, __LINE__, __PRETTY_FUNCTION__).reference() << MSG; } while(0)
+
+
 
 #endif // GDE_CORE_LOG_HPP

--- a/src/GDE/Core/App.cpp
+++ b/src/GDE/Core/App.cpp
@@ -3,6 +3,9 @@
 #include <GDE/Core/StringsUtil.hpp>
 #include <GDE/Core/ConfigReader.hpp>
 #include <GDE/Core/ConfigCreate.hpp>
+#include <fstream>
+
+static std::ofstream logFile;
 
 namespace GDE
 {
@@ -15,15 +18,20 @@ App::App()
 	, running(false)
 	, initialScene(NULL)
 {
-	// Se inicializa el sistema de loggin
-	GDE::Log::init("log.txt");
+	// Se abre el archivo donde se guardará el loggin
+	logFile.open("log.txt", std::ios::app);
+
+	// Se inicializa el sistema de loggin con el archivo
+	GDE::Log::init(logFile);
 	
-	GDE::Log::info("App::App()", "Constructor llamado");
+	GDE_LOG_INFO("App: constructor llamado");
 }
 
 App::~App()
 {
-	GDE::Log::info("App::~App()", "Destructor llamado");
+	// Termina el sistema de loggin antes de cerrar el archivo
+	GDE::Log::close();
+	GDE_LOG_INFO("App: destructor llamado");
 }
 
 App* App::instance()
@@ -65,11 +73,11 @@ void App::setFirstScene(Scene* scene)
 	if (this->initialScene == NULL)
 	{
 		initialScene = scene;
-		GDE::Log::info("App::setFirstScene()", "Establecida escena inicial ID=" + scene->getID());
+		GDE_LOG_INFO("App::setFirstScene(): establecida escena inicial ID =" << scene->getID());
 	}
 	else
 	{
-		GDE::Log::warning("App::setFirstScene()", "Ya se ha establecido una escena inicial");
+		GDE_LOG_WARNING("App::setFirstScene(): ya se ha establecido una escena inicial");
 	}
 }
 
@@ -86,7 +94,7 @@ sf::Int16 App::run()
 	// Se encarga de la limpieza y cerrar todos los subsistemas
 	this->cleanup();
 	// Escribimos en el log el código de salida
-	GDE::Log::debug("Código de salida", GDE::StringFormat("%d", this->exitCode));
+	GDE_LOG_DEBUG("App: Código de salida: " << this->exitCode);
 	// Salimos con el código de salida generado
 	return this->exitCode;
 }
@@ -107,12 +115,12 @@ void App::init()
 	}
 	else
 	{
-		GDE::Log::error("App::Init()", "No se ha establecido escena inicial. LLamar a App::SetFirstScene() primero");
+		GDE_LOG_ERROR("App::init(): no se ha establecido escena inicial. LLamar a App::setFirstScene() primero");
 		// Salimos con código -2
 		quit(GDE::StatusAppInitFailed);
 	}
 
-	GDE::Log::info("App::Init()", "Completado");
+	GDE_LOG_DEBUG("App::init(): completado");
 }
 
 void App::createWindow()
@@ -177,12 +185,11 @@ void App::createWindow()
 	newConf.close();
 
 	// Escribimos en el log
-	GDE::Log::info("App::createWindow", "Ventana creada");
-	GDE::Log::info("Modo de Video", GDE::convertInt32(videoMode.width) + 
-		"x" + GDE::convertInt32(videoMode.height) + 
-		"x" + GDE::convertInt32(videoMode.bitsPerPixel));
-	GDE::Log::info("Vsync", GDE::convertBool(vsync));
-	GDE::Log::info("Fullscreen", GDE::convertBool(fullscreen));
+	GDE_LOG_INFO("App::createWindow(): ventana creada");
+	GDE_LOG_INFO("Modo de Video:" << GDE::Log::nospace
+					<< videoMode.width << "x" << videoMode.height << "x" << videoMode.bitsPerPixel);
+	GDE_LOG_INFO("Vsync:" << vsync);
+	GDE_LOG_INFO("Fullscreen:" << fullscreen);
 }
 
 void App::gameLoop()
@@ -241,7 +248,7 @@ void App::cleanup()
 	sceneManager->release();
 	sceneManager = NULL;
 	
-	GDE::Log::info("App::cleanup()", "Completado");
+	GDE_LOG_DEBUG("App::cleanup(): completado");
 }
 	
 } // namespace GDE

--- a/src/GDE/Core/ConfigReader.cpp
+++ b/src/GDE/Core/ConfigReader.cpp
@@ -164,7 +164,7 @@ bool ConfigReader::loadFromFile(const std::string& theFilename)
     unsigned long anCount = 1;
 
 	// Indicamos en el log que estamos cargando un fichero
-    GDE::Log::info("ConfigReader::loadFromFile","Abriendo fichero "+theFilename+".");
+	GDE_LOG_INFO("ConfigReader::loadFromFile(): abriendo fichero" << theFilename);
 
     // Intentamos abrir el fichero
     FILE* anFile = fopen(theFilename.c_str(), "r");
@@ -181,7 +181,7 @@ bool ConfigReader::loadFromFile(const std::string& theFilename)
                 // Si ocurre un error lo metemos en el log
                 if (!feof(anFile))
                 {
-                    GDE::Log::error("ConfigReader::Read", StringFormat("Error leyendo la línea %d", anCount));
+					GDE_LOG_ERROR("ConfigReader::Read(): error leyendo la línea" << anCount);
                 }
                 // Salimos del bucle
                 break;
@@ -204,7 +204,7 @@ bool ConfigReader::loadFromFile(const std::string& theFilename)
     }
     else
     {
-        GDE::Log::error("ConfigReader::loadFromFile", StringFormat("Error al leer fichero %s .", theFilename.c_str()));
+		GDE_LOG_ERROR("ConfigReader::Read(): error leyendo la línea" << anCount);
     }
 
     // Devuelve true en caso de éxito, false en caso contrario
@@ -281,8 +281,7 @@ std::string ConfigReader::parseLine(const char* theLine,
                 }
                 else
                 {
-                    GDE::Log::error("ConfigReader::parseLine",
-									StringFormat("No se encontró el delimitador de sección ']' en la línea %d", theCount));
+					GDE_LOG_ERROR("No se encontró el delimitador de sección ']' en la línea" << theCount);
                 }
             }
             // Leemos el par <clave,valor> de la sección actual.
@@ -354,8 +353,7 @@ std::string ConfigReader::parseLine(const char* theLine,
                 }
                 else
                 {
-                    GDE::Log::error("ConfigReader::parseLine",
-									StringFormat("No se encontró el delimitador de nombre o valor '=' o ':' en la línea %d", theCount));
+					GDE_LOG_ERROR("No se encontró el delimitador de nombre o valor '=' o ':' en la línea" << theCount);
                 }
             }
         } // if(theLine[anOffset] != '#' && theLine[anOffset] != ';')
@@ -380,8 +378,8 @@ void ConfigReader::storeNameValue(const std::string theSection,
         // Nos aseguramos de que hemos creado el mapa correctamente
         if (NULL != anMap)
         {
-            GDE::Log::info("ConfigReader::StoreNameValue","Añadiendo "+theName+"="+theValue + " a la sección [" + theSection+"].");
-
+			GDE_LOG_INFO("ConfigReader::StoreNameValue(): añadiendo" << theName << "=" << theValue << GDE::Log::nospace
+							<< "a la sección [" << theSection << "]");
             // Añadimos el nuevo par <clave,valor> al mapa
             anMap->insert(std::pair<const std::string, const std::string>(theName, theValue));
 
@@ -390,7 +388,8 @@ void ConfigReader::storeNameValue(const std::string theSection,
         }
         else
         {
-            GDE::Log::error("ConfigReader::StoreNameValue","Imposible añadir "+theName+"="+theValue + " a la sección [" + theSection+"] posible falta de memoria.");
+			GDE_LOG_ERROR("Imposible añadir" << theName << "=" << theValue << GDE::Log::nospace
+							<< "a la sección [" << theSection << "], posible falta de memoria.");
         }
     }
     else
@@ -406,13 +405,15 @@ void ConfigReader::storeNameValue(const std::string theSection,
             iterNameValue = anMap->find(theName);
             if (iterNameValue == anMap->end())
             {
-                GDE::Log::info("ConfigReader::StoreNameValue","Añadiendo "+theName+"="+theValue + " a la sección [" + theSection+"].");
+				GDE_LOG_INFO("ConfigReader::StoreNameValue(): añadiendo" << theName << "=" << theValue <<  GDE::Log::nospace
+								<< "a la sección [" << theSection << "]");
                 // Añadimos el nuevo par <clave,valor>
                 anMap->insert(std::pair<const std::string, const std::string>(theName, theValue));
             }
             else
             {
-                GDE::Log::error("ConfigReader::StoreNameValue","Imposible añadir "+theName+"="+theValue + " a la sección [" + theSection+"] porque ya existe.");
+				GDE_LOG_ERROR("Imposible añadir" << theName << "=" << theValue << GDE::Log::nospace
+								<< "a la sección [" << theSection << "], porque ya existe.");
             }
         }
     } // else(iterSection == mSections.end())

--- a/src/GDE/Core/Log.cpp
+++ b/src/GDE/Core/Log.cpp
@@ -1,76 +1,140 @@
-#include <GDE/Config.hpp>
 #include <GDE/Core/Log.hpp>
+#include <iostream>
+#include <fstream>
+
+
+static std::string headerStringList[] = {"DEBUG", "INFO", "WARNING", "ERROR"};
+
+// Controlador por defecto. Este método es llamado por el destructor de GDE::Log cada vez que
+// un mensaje debe ser escrito al flujo. Si no se ha instalado un controlador personalizado
+// se usará este.
+static void defaultLogHandler (std::ostream &os,
+							   GDE::LogLevel level,
+							   const std::string &message,
+							   const std::string &date,
+							   const std::string &time,
+							   const GDE::SourceContext &context
+							  )
+{
+	os << time << " " << headerStringList[level] << ": ";
+	if (level == GDE::Error)
+	{
+		os << context.file << ":" << context.line << " en la función: " << context.function << ": ";
+	}
+	os << message;
+}
 
 namespace GDE
 {
-    
+
 bool Log::initialized = false;
 time_t Log::rawtime;
-std::string Log::logFileName;
-std::string Log::header[] = {"INFO", "DEBUG", "ERROR", "WARNING"};
+std::ostream *Log::outputStream = NULL;
+LogHandler Log::handler = defaultLogHandler;
 
-void Log::init(std::string logFileName)
+
+
+Log::Log (LogLevel level, const char *file, int line, const char *function)
+	: context(file, line, function)
 {
-	if(!initialized)
-	{
-		Log::logFileName = logFileName;
-		initialized = true;
-		std::cout << "Sistema de Log inicializado" << std::endl;
-		std::ofstream logFile(Log::logFileName.c_str(), std::ofstream::app);
-		time (&rawtime);
-		char buffer[20];
-		struct tm * timeinfo;
-		timeinfo = localtime(&rawtime);
-		strftime(buffer, 20, "%d/%m/%y %X ", timeinfo);
-		logFile << std::endl;
-		logFile << "=====================================================================";
-		logFile << std::endl;
-		logFile << buffer << "SISTEMA DE LOG INICIALIZADO" << std::endl;
-		logFile << "=====================================================================";
-		logFile << std::endl;
-		logFile.close();
-	}
+	// Asume autoespaciado por defecto
+	this->autoSpacing = true;
+	this->level = level;
 }
 
-void Log::info(std::string tag, std::string text)
-{
-	Log::log(tag, text, GDE::infoLevel);
-}
 
-void Log::debug(std::string tag, std::string text)
-{
-#ifdef GDE_DEBUG
-   Log::log(tag, text, GDE::debugLevel);
-#endif // GDE_DEBUG
-}
-
-void Log::error(std::string tag, std::string text)
-{
-   Log::log(tag, text, GDE::errorLevel);
-}
-
-void Log::warning(std::string tag, std::string text)
-{
-   Log::log(tag, text, GDE::warningLevel);
-}
-
-void Log::log(std::string tag, std::string text, int logType)
+Log::~Log ()
 {
 	if (!initialized)
 	{
-		std::cout << "El sistema de log no ha sido inicializado, por favor, inicielo mediante GDE::Log::init()" << std::endl;
+		std::cerr << "El sistema de log no ha sido inicializado o ha sido cerrado.";
+		std::cerr << "Por favor, inicielo mediante GDE::Log::init()" << std::endl;
 		return;
 	}
-	std::ofstream logFile(Log::logFileName.c_str(), std::ofstream::app);
-	time (&rawtime);
-	char buffer [20];
-	struct tm * timeinfo;
-	timeinfo = localtime (&rawtime);
-	strftime (buffer,20,"%d/%m/%y %X ",timeinfo);
-	logFile << buffer << header[logType] << ": " << tag << ": " << text << std::endl;
-	logFile.close();
-  
+
+	// Se asegura que siempre exista un handler instalado o se use el handler por defecto
+	if (!handler)
+	{
+		handler = defaultLogHandler;
+	}
+
+	// Llama al handler instalado pasando los parámetros necesarios.
+	// TODO Separar la fecha de la hora.
+	(*handler)(*outputStream, level, textStream.str(), "---", actualTimeToText(), context);
+	*outputStream << std::endl;
 }
 
+
+void Log::init (std::ostream &stream)
+{
+	if (!initialized)
+	{
+		initialized = true;
+		outputStream = &stream;
+		std::cout << "Sistema de Log inicializado" << std::endl;
+
+		*outputStream << std::endl;
+		*outputStream << "=====================================================================";
+		*outputStream << std::endl;
+		*outputStream << actualTimeToText() << "SISTEMA DE LOG INICIALIZADO" << std::endl;
+		*outputStream << "=====================================================================";
+		*outputStream << std::endl;
+	}
+}
+
+void Log::close ()
+{
+	initialized = false;
+	outputStream = NULL;
+	std::cout << "Sistema de Log cerrado" << std::endl;
+}
+
+
+Log& Log::operator<< (bool b)
+{
+	this->textStream << (b ? "true" : "false");
+	return maybeSpace();
+}
+
+Log& Log::operator<< (const std::string &str)
+{
+	this->textStream << "\"" << str << "\"";
+	return maybeSpace();
+}
+
+
+Log& Log::space (Log &o)
+{
+	o.autoSpacing = true;
+	return o;
+}
+
+Log& Log::nospace (Log &o)
+{
+	o.autoSpacing = false;
+	return o;
+}
+
+
+Log& Log::maybeSpace()
+{
+	if (this->autoSpacing)
+	{
+		textStream << ' ';
+	}
+
+	return *this;
+}
+
+std::string Log::actualTimeToText()
+{
+	time (&rawtime);
+	char buffer[20];
+	struct tm * timeinfo;
+	timeinfo = localtime(&rawtime);
+	strftime(buffer, 20, "%d/%m/%y %X ", timeinfo);
+
+	return buffer;
+}
 
 } // namespace GDE

--- a/src/GDE/Core/SceneManager.cpp
+++ b/src/GDE/Core/SceneManager.cpp
@@ -11,12 +11,12 @@ SceneManager::SceneManager()
 	, inactivesScenes()
 	, nextScene("")
 {
-	GDE::Log::debug("SceneManager", "Constructor llamado");
+	GDE_LOG_DEBUG("SceneManager: Constructor llamado");
 }
 
 SceneManager::~SceneManager()
 {
-	GDE::Log::debug("SceneManager", "Destructor llamado");
+	GDE_LOG_DEBUG("SceneManager: Destructor llamado");
 }
 
 SceneManager* SceneManager::instance()
@@ -44,7 +44,7 @@ void SceneManager::addScene(Scene* theScene)
 	if (it != this->inactivesScenes.end())
 	{
 		// Si ya existe la escena salimos sin cambios
-		GDE::Log::warning("SceneManager::AddScene", "ya existe una escena con ID=" + theScene->getID() + " se omite");
+		GDE_LOG_WARNING("SceneManager::AddScene(): ya existe una cadena con ID =" << theScene->getID() << "se omite");
 		return;
 	}
 
@@ -54,7 +54,7 @@ void SceneManager::addScene(Scene* theScene)
 	// Inicializamos la escena
 	theScene->init();
 	
-	GDE::Log::info("SceneManager::AddScene", "Añadida escena con ID=" + theScene->getID());
+	GDE_LOG_INFO("SceneManager::AddScene(): añadida escena con ID =" << theScene->getID());
 }
 
 void SceneManager::setActiveScene(sceneID thesceneID)
@@ -70,11 +70,11 @@ void SceneManager::setActiveScene(sceneID thesceneID)
 	// Comprobamos si es la escena activa
 	if (thesceneID == this->activeScene->getID())
 	{
-		GDE::Log::info("SceneManager::SetActiveScene()", "la escena con ID=" + thesceneID + "ya esta activa");
+		GDE_LOG_INFO("SceneManager::SetActiveScene(): la escena con ID =" << thesceneID << "ya está activa");
 		return;
 	}
 
-	GDE::Log::warning("SceneManager::SetActiveScene()",  "No existe ninguna escena con ID=" + thesceneID);
+	GDE_LOG_WARNING("SceneManager::SetActiveScene(): no existe ninguna escena con ID =" << thesceneID);
 }
 
 void SceneManager::removeScene(sceneID thesceneID)
@@ -83,7 +83,7 @@ void SceneManager::removeScene(sceneID thesceneID)
 	std::map<sceneID, Scene*>::iterator it = this->inactivesScenes.find(thesceneID);
 	if (it != this->inactivesScenes.end())
 	{
-		GDE::Log::info("SceneManager::RemoveScene()", "Eliminada escena con ID=" + thesceneID);
+		GDE_LOG_INFO("SceneManager::RemoveScene(): eliminada escena con ID =" << thesceneID);
 		it->second->cleanup();
 		delete it->second;
 		this->inactivesScenes.erase(it);
@@ -93,11 +93,11 @@ void SceneManager::removeScene(sceneID thesceneID)
 	// Comprobamos si está intentando eliminar la escena activa
 	if (thesceneID == this->activeScene->getID())
 	{
-		GDE::Log::warning("SceneManager::RemoveScene()", "La escena con ID=" + thesceneID + "esta activa y no se puede eliminar");
+		GDE_LOG_WARNING("SceneManager::RemoveScene(): La escena con ID =" << thesceneID << "está activa y no se puede eliminar");
 		return;
 	}
 
-	GDE::Log::warning("SceneManager::RemoveScene()",  "No existe ninguna escena con ID=" + thesceneID);
+	GDE_LOG_WARNING("SceneManager::RemoveScene(): no existe ninguna escena con ID =" << thesceneID);
 }
 
 void SceneManager::removeAllInactiveScene()
@@ -106,7 +106,7 @@ void SceneManager::removeAllInactiveScene()
 	std::map<sceneID, Scene*>::iterator it = this->inactivesScenes.begin();
 	while(it != this->inactivesScenes.end())
 	{
-		GDE::Log::info("SceneManager::RemoveAllInactiveScene()", "Eliminada escena con ID=" + it->first);
+		GDE_LOG_INFO("SceneManager::RemoveAllInactiveScene(): Eliminada escena con ID =" << it->first);
 		it->second->cleanup();
 		delete it->second;
 		this->inactivesScenes.erase(it++);
@@ -131,7 +131,7 @@ void SceneManager::changeScene(sceneID thesceneID)
 	this->inactivesScenes.erase(thesceneID);
 	this->activeScene->active();
 
-	GDE::Log::info("SceneManager::ChangeScene()", "Activa escena con ID=" + thesceneID);
+	GDE_LOG_INFO("SceneManager::ChangeScene(): activa escena con ID =" << thesceneID);
 }
 
 void SceneManager::removeAllScene()
@@ -142,7 +142,7 @@ void SceneManager::removeAllScene()
 	if (this->activeScene != NULL)
 	{
 		// Eliminamos la escena activa
-		GDE::Log::info("SceneManager::RemoveAllScene()", "Eliminada escena con ID=" + this->activeScene->getID());
+		GDE_LOG_INFO("SceneManager::RemoveAllScene(): eliminada escena con ID=" << this->activeScene->getID());
 		this->activeScene->cleanup();
 		delete this->activeScene;
 		this->activeScene = NULL;


### PR DESCRIPTION
Basándome en los comentarios del isseu #67 he modificado mi anterior propuesta. La base sigue siendo la misma, pero se diferencia principalmente en:
- Las macros se utilizan en la forma `GDE_LOG_INFO("hola" << "mundo");` para admitir la posibilidad de omitir completamente los logs en ciertos modos de construcción.
- Log::init() ya no administra el archivo, si no que pide una referencia a un flujo de tipo `std::ostream` que debe ser gestionado por el llamador de la clase (más información en la documentación doxygen al inicio de la clase Log). Las principales ventajas de esto es que se puede escribir en archivos, cadenas de texto o en la salida estándar tan solo cambiando el parámetro del método Log::init().
- El parámetro etiqueta se ha eliminado. Se deja la posibilidad de seguir usando la etiqueta con un manipulador de la forma `tag("etiqueta")`, si bien, aun no está implementada.
- Mientras que aun es el destructor de la clase Log quien comienza la escritura en el flujo (archivo), la responsabilidad de escribir el mensaje recae ahora en una función llamada _handler_  de mensajes, la cual puede personalizarse a fin de personalizar la forma en que los mensajes pueden escribirse. Esta función aun no está completamente terminada.

Si bien, no todo está aun terminado, la clase ya es totalmente utilizable.

El commit es bastante grande, dado que tuve que modificar todas las llamadas previas a GDE::Log:info() para adaptarse a la nueva sintaxis. Además, la documentación de la clase es bastante extensa.

Atento a sus comentarios. Saludos!
